### PR TITLE
index/publisher_detail: Add new stats now available

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -27,7 +27,7 @@
         </td>
         <td>
           <a name="{{csPublisherId}}"></a>
-          <a href="{{url}}">{{name}}</a>
+          <a href="{{url}}">{{name}} {{csPublisherId}}</a>
         </td>
         <td>
           <a href="#{{csPublisherId}}" data-cs-publisher-id="{{csPublisherId}}">{{feedCount}}</a>

--- a/views/publisher_detail.hbs
+++ b/views/publisher_detail.hbs
@@ -3,26 +3,32 @@
     <tr>
       <th scope="col">Feed</th>
       <th scope="col">Data items passing validation (%)</th>
-      <th scope="col"></th>
+      <th scope="col">Validation errors</th>
+      <th scope="col">Normalised data profile score (lower better)</th>
     </tr>
   </thead>
   <tbody>
     {{#each publisherDetails.feeds}}
     <tr>
       <td>
-        <a href="{{url}}">{{name}}</a>
+        <a href="{{url}}">{{name}}</a> <small>{{csFeedId}}</small>
       </td>
       <td>
-        {{#if validationDonePercent }}
-        <span title="{{validationDonePercent}}% of items assessed">{{validPercent}}</span>
+        {{#if stats.percentValidationDone }}
+        <span title="{{stats.percentValidationDone}}% of items assessed">{{stats.percentValidationPass}}</span>
         {{else}}
         Validation not yet started
         {{/if}}
       </td>
       <td>
-        {{#if validationDonePercent }}
+        {{#if stats.percentValidationDone }}
         <a href="{{../publisherDetailsUrl}}/feed/{{csFeedId}}/errors">{{name}} Validation Results (JSON)</a>
         {{/if}}
+      </td>
+      <td>
+       {{#each stats.profileStats}}
+         {{dataProfileName}}:{{score}} <br />
+       {{/each}}
       </td>
     </tr>
     {{/each}}


### PR DESCRIPTION
We can display the profile score now that this module has been merged
into conformance-services
(https://github.com/openactive/conformance-services/commit/22b3c71be15ac7a174dffbea16798771098cef73)
The changes also reflect the need to traverse into the stats object
which is now on the api.